### PR TITLE
fix: Changed preconfigured_waf_config_exclusion to a list to allow multiple exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "security_policy" {
       target_rule_set         = "xss-v33-stable"
       sensitivity_level       = 2
       exclude_target_rule_ids = ["owasp-crs-v030301-id941380-xss", "owasp-crs-v030301-id941280-xss"]
-      preconfigured_waf_config_exclusion = {
+      preconfigured_waf_config_exclusion = [{
         target_rule_set = "xss-v33-stable"
         target_rule_ids = ["owasp-crs-v030301-id941140-xss", "owasp-crs-v030301-id941270-xss"]
         request_header = [
@@ -93,7 +93,7 @@ module "security_policy" {
           },
         ]
       }
-    }
+    }]
 
     "php-stable_level_0_with_include" = {
       action                  = "deny(502)"

--- a/examples/simple-example/main.tf
+++ b/examples/simple-example/main.tf
@@ -56,29 +56,30 @@ module "cloud_armor" {
       target_rule_set   = "sqli-v33-stable"
       sensitivity_level = 4
 
-      preconfigured_waf_config_exclusion = {
-        target_rule_set = "sqli-v33-stable"
-        request_cookie = [
-          {
-            operator = "EQUALS_ANY"
-          },
-          {
-            operator = "STARTS_WITH"
-            value    = "abc"
-          }
-        ]
-        request_header = [
-          {
-            operator = "STARTS_WITH"
-            value    = "xyz"
-          },
-          {
-            operator = "STARTS_WITH"
-            value    = "uvw"
-          }
-        ]
-      }
-
+      preconfigured_waf_config_exclusion = [
+        {
+          target_rule_set = "sqli-v33-stable"
+          request_cookie = [
+            {
+              operator = "EQUALS_ANY"
+            },
+            {
+              operator = "STARTS_WITH"
+              value    = "abc"
+            }
+          ]
+          request_header = [
+            {
+              operator = "STARTS_WITH"
+              value    = "xyz"
+            },
+            {
+              operator = "STARTS_WITH"
+              value    = "uvw"
+            }
+          ]
+        }
+      ]
     }
 
     "xss-stable_level_2_with_exclude" = {
@@ -90,31 +91,42 @@ module "cloud_armor" {
       sensitivity_level       = 2
       exclude_target_rule_ids = ["owasp-crs-v030301-id941380-xss", "owasp-crs-v030301-id941280-xss"]
 
-      preconfigured_waf_config_exclusion = {
-        target_rule_set = "xss-v33-stable"
-        target_rule_ids = ["owasp-crs-v030301-id941140-xss", "owasp-crs-v030301-id941270-xss"]
-        request_header = [
-          {
-            operator = "STARTS_WITH"
-            value    = "abc"
-          },
-          {
-            operator = "ENDS_WITH"
-            value    = "xyz"
-          }
-        ]
-        request_uri = [
-          {
-            operator = "CONTAINS"
-            value    = "https://hashicorp.com"
-          },
-          {
-            operator = "CONTAINS"
-            value    = "https://xyz.com"
-          },
-        ]
-      }
-
+      preconfigured_waf_config_exclusion = [
+        {
+          target_rule_set = "xss-v33-stable"
+          target_rule_ids = ["owasp-crs-v030301-id941140-xss", "owasp-crs-v030301-id941270-xss"]
+          request_header = [
+            {
+              operator = "STARTS_WITH"
+              value    = "abc"
+            },
+            {
+              operator = "ENDS_WITH"
+              value    = "xyz"
+            }
+          ]
+          request_uri = [
+            {
+              operator = "CONTAINS"
+              value    = "https://hashicorp.com"
+            },
+            {
+              operator = "CONTAINS"
+              value    = "https://xyz.com"
+            }
+          ]
+        },
+        {
+          target_rule_set = "xss-v33-stable"
+          target_rule_ids = ["owasp-crs-v030301-id941330-xss", "owasp-crs-v030301-id941340-xss"]
+          request_uri = [
+            {
+              operator = "STARTS_WITH"
+              value    = "/def"
+            }
+          ]
+        }
+      ]
     }
 
     "php-stable_level_0_with_include" = {

--- a/main.tf
+++ b/main.tf
@@ -169,37 +169,40 @@ resource "google_compute_security_policy" "policy" {
 
       # Optional preconfigured_waf_config Block if preconfigured_waf_config_exclusion is provided
       dynamic "preconfigured_waf_config" {
-        for_each = rule.value.preconfigured_waf_config_exclusion.target_rule_set == null ? [] : ["preconfigured_waf_config_exclusion"]
+        for_each = rule.value.preconfigured_waf_config_exclusion == null ? [] : ["preconfigured_waf_config_exclusion"]
         content {
-          exclusion {
-            target_rule_set = rule.value.preconfigured_waf_config_exclusion.target_rule_set
-            target_rule_ids = rule.value.preconfigured_waf_config_exclusion.target_rule_ids
-            dynamic "request_header" {
-              for_each = rule.value.preconfigured_waf_config_exclusion.request_header == null ? {} : { for x in rule.value.preconfigured_waf_config_exclusion.request_header : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
-              content {
-                operator = request_header.value.operator
-                value    = request_header.value.operator == "EQUALS_ANY" ? null : request_header.value.value
+          dynamic "exclusion" {
+            for_each = rule.value.preconfigured_waf_config_exclusion
+            content {
+              target_rule_set = exclusion.value.target_rule_set
+              target_rule_ids = exclusion.value.target_rule_ids
+              dynamic "request_header" {
+                for_each = exclusion.value.request_header == null ? {} : { for x in rule.value.request_header : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
+                content {
+                  operator = request_header.value.operator
+                  value    = request_header.value.operator == "EQUALS_ANY" ? null : request_header.value.value
+                }
               }
-            }
-            dynamic "request_cookie" {
-              for_each = rule.value.preconfigured_waf_config_exclusion.request_cookie == null ? {} : { for x in rule.value.preconfigured_waf_config_exclusion.request_cookie : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
-              content {
-                operator = request_cookie.value.operator
-                value    = request_cookie.value.operator == "EQUALS_ANY" ? null : request_cookie.value.value
+              dynamic "request_cookie" {
+                for_each = exclusion.value.request_cookie == null ? {} : { for x in exclusion.value.request_cookie : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
+                content {
+                  operator = request_cookie.value.operator
+                  value    = request_cookie.value.operator == "EQUALS_ANY" ? null : request_cookie.value.value
+                }
               }
-            }
-            dynamic "request_uri" {
-              for_each = rule.value.preconfigured_waf_config_exclusion.request_uri == null ? {} : { for x in rule.value.preconfigured_waf_config_exclusion.request_uri : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
-              content {
-                operator = request_uri.value.operator
-                value    = request_uri.value.operator == "EQUALS_ANY" ? null : request_uri.value.value
+              dynamic "request_uri" {
+                for_each = exclusion.value.request_uri == null ? {} : { for x in exclusion.value.request_uri : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
+                content {
+                  operator = request_uri.value.operator
+                  value    = request_uri.value.operator == "EQUALS_ANY" ? null : request_uri.value.value
+                }
               }
-            }
-            dynamic "request_query_param" {
-              for_each = rule.value.preconfigured_waf_config_exclusion.request_query_param == null ? {} : { for x in rule.value.preconfigured_waf_config_exclusion.request_query_param : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
-              content {
-                operator = request_query_param.value.operator
-                value    = request_query_param.value.operator == "EQUALS_ANY" ? null : request_query_param.value.value
+              dynamic "request_query_param" {
+                for_each = exclusion.value.request_query_param == null ? {} : { for x in exclusion.value.request_query_param : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
+                content {
+                  operator = request_query_param.value.operator
+                  value    = request_query_param.value.operator == "EQUALS_ANY" ? null : request_query_param.value.value
+                }
               }
             }
           }
@@ -463,5 +466,4 @@ resource "google_compute_security_policy" "policy" {
       }
     }
   }
-
 }

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "google_compute_security_policy" "policy" {
               target_rule_set = exclusion.value.target_rule_set
               target_rule_ids = exclusion.value.target_rule_ids
               dynamic "request_header" {
-                for_each = exclusion.value.request_header == null ? {} : { for x in rule.value.request_header : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
+                for_each = exclusion.value.request_header == null ? {} : { for x in exclusion.value.request_header : "${x.operator}-${base64encode(coalesce(x.value, "test"))}" => x }
                 content {
                   operator = request_header.value.operator
                   value    = request_header.value.operator == "EQUALS_ANY" ? null : request_header.value.value

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "pre_configured_rules" {
       header_value = optional(string)
     })), [])
 
-    preconfigured_waf_config_exclusion = optional(object({
+    preconfigured_waf_config_exclusion = optional(list(object({
       target_rule_set = string
       target_rule_ids = optional(list(string), [])
       request_header = optional(list(object({
@@ -94,7 +94,7 @@ variable "pre_configured_rules" {
         operator = string
         value    = optional(string)
       })))
-    }), { target_rule_set = null })
+    })), [])
 
   }))
 


### PR DESCRIPTION
I encountered an issue with the "preconfigured_waf_config_exclusion" feature, which only seemed to allow the creation of a single exclusion instead of supporting multiple exclusions. To verify that multiple exclusions were indeed possible, I utilized the gcloud CLI and was able to create a Cloud Armor policy with multiple waf exclusions.

I made modifications to the "variables.tf" and "main.tf" files by changing preconfigured_waf_config_exclusion to a list of exclusions. Another option would be the introduction of another variable `preconfigured_waf_config_exclusions` for this to not be a breaking change. (but that might be confusing) 