### PR TITLE
Version support for Regional Backend Service Module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -27,9 +27,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-cloud-armor/v2.2.0"
+    module_name = "blueprints/terraform/terraform-google-cloud-armor/v2.2.0" # Does this need to be updated to 3.0 to support the regional backend service module (PR#126)?
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-cloud-armor/v2.2.0"
+    module_name = "blueprints/terraform/terraform-google-cloud-armor/v2.2.0" # Does this need to be updated to 3.0 to support the regional backend service module (PR#126)?
   }
 }


### PR DESCRIPTION
Hi! Thanks for creating PR#126 to support the regional external application load balancers. Does the versioning need to be adjusted to support the new module (i.e., 3.0)?

Receiving the following error:
There is no available version of module "registry.terraform.io/GoogleCloudPlatform/cloud-armor/google//modules/regional-backend-security-policy." The newest available version is 2.2.0.